### PR TITLE
refactor: Revise distance calculation and matrix export

### DIFF
--- a/src/huetracer/plotting/plot.py
+++ b/src/huetracer/plotting/plot.py
@@ -2627,21 +2627,13 @@ def create_report_plots(
     """
     print("--- Generating plots... ---")
 
-    # Build pixel-space coordinates from AnnData directly (consistent with widgets).
-    scalefactors = sp_adata_microenvironment.uns["spatial"][lib_id].get("scalefactors", {})
-    scalef = float(scalefactors.get(f"tissue_{img_key}_scalef", 1.0))
-    coords = np.asarray(sp_adata_microenvironment.obsm[basis], dtype=np.float64) * scalef
+    # Import locally to avoid adding a module-level plotting -> widgets dependency.
+    from ..widgets.selection import _build_merged_df
+
     hires_img = sp_adata_microenvironment.uns["spatial"][lib_id]["images"][img_key]
     h, w = hires_img.shape[:2]
 
-    merged = pd.DataFrame(
-        {
-            "x": coords[:, 0],
-            "y": coords[:, 1],
-            "predicted_microenvironment": sp_adata_microenvironment.obs["predicted_microenvironment"].values,
-        },
-        index=sp_adata_microenvironment.obs_names,
-    )
+    merged = _build_merged_df(sp_adata_microenvironment, lib_id, basis, img_key)
 
     # === 1. 空間散布図の作成 ===
     group_order = sorted(merged["predicted_microenvironment"].dropna().unique())

--- a/src/huetracer/plotting/plot.py
+++ b/src/huetracer/plotting/plot.py
@@ -45,8 +45,8 @@ def _downsample_plotly_background(img, factor):
 def plot_spatial_plotly_fast(
     adata,
     color_col="predicted_microenvironment",
-    basis="spatial_cropped_150_buffer",
     lib_id=None,
+    basis="spatial_cropped_150_buffer",
     img_key="0.5_mpp_150_buffer",
     downsample_img=0.25,
     max_points=250_000,
@@ -64,10 +64,10 @@ def plot_spatial_plotly_fast(
         Spatial AnnData object.
     color_col : str
         Column in ``adata.obs`` used for categorical coloring.
-    basis : str
-        Key in ``adata.obsm`` containing 2D spatial coordinates.
     lib_id : str or None
         Spatial library id. If None, the first available library is used.
+    basis : str
+        Key in ``adata.obsm`` containing 2D spatial coordinates.
     img_key : str
         Background image key inside ``adata.uns['spatial'][lib_id]['images']``.
     downsample_img : float
@@ -153,7 +153,7 @@ def plot_spatial_plotly_fast(
     unique_labels = pd.unique(sampled_labels)
     palette = sns.color_palette("tab20", n_colors=max(20, len(unique_labels)))
     color_map = {
-        label: f"rgb({int(r * 255)},{int(g * 255)},{int(b * 255)})"
+        label: (int(r * 255), int(g * 255), int(b * 255))
         for label, (r, g, b) in zip(unique_labels, palette)
     }
 
@@ -175,6 +175,8 @@ def plot_spatial_plotly_fast(
         label_mask = sampled_labels == label
         if not np.any(label_mask):
             continue
+        r, g, b = color_map[label]
+        rgba_color = f"rgba({r},{g},{b},{point_opacity})"
         fig.add_trace(
             go.Scattergl(
                 x=x[label_mask],
@@ -183,8 +185,7 @@ def plot_spatial_plotly_fast(
                 name=str(label),
                 marker={
                     "size": point_size,
-                    "opacity": point_opacity,
-                    "color": color_map[label],
+                    "color": rgba_color,
                 },
                 hoverinfo="skip",
             )
@@ -2590,36 +2591,58 @@ def plot_volcano_between_microenvironments(
 
 # --- 関数定義 ---
 def create_report_plots(
-    merged: pd.DataFrame,
     sp_adata_microenvironment: ad.AnnData,
-    hires_img: np.ndarray,
-    w: int,
-    h: int,
+    lib_id: str,
     sample_name: str,
-    save_path: str
+    save_path: str,
+    basis: str = "spatial_cropped_150_buffer",
+    img_key: str = "0.5_mpp_150_buffer",
 ) -> None:
     """
-    提供されたデータから空間散布図と構成比率ヒートマップを作成し、保存します。
+    空間散布図と構成比率ヒートマップを作成し、保存します。
+
+    座標と背景画像は ``sp_adata_microenvironment`` から直接取得するため、
+    ノートブック側で ``merged`` / ``hires_img`` / ``w`` / ``h`` を
+    事前に作成する必要はありません。
 
     Parameters
     ----------
-    merged : pd.DataFrame
-        'x', 'y', 'predicted_microenvironment'列を含むDataFrame。
     sp_adata_microenvironment : ad.AnnData
         `.obs`に'predicted_microenvironment'と'predicted_cell_type'を含むAnnDataオブジェクト。
-    hires_img : np.ndarray
-        散布図の背景となる高解像度画像。
-    w : int
-        画像の幅。
-    h : int
-        画像の高さ。
+        ``obsm[basis]`` に2次元座標、``uns['spatial'][lib_id]`` に画像データが必要。
+    lib_id : str
+        ``sp_adata_microenvironment.uns['spatial']`` 内のライブラリIDキー。
     sample_name : str
         保存ファイル名に使用するサンプル名。
     save_path : str
         プロットを保存するディレクトリパス。
+    basis : str
+        ``sp_adata_microenvironment.obsm`` 内の2次元座標キー。
+        デフォルト ``'spatial_cropped_150_buffer'``。
+        標準Visium/Visium HDの場合は ``'spatial'`` を指定してください。
+    img_key : str
+        背景画像キー。``basis='spatial_cropped_150_buffer'`` の場合は
+        ``'0.5_mpp_150_buffer'``、``basis='spatial'`` の場合は ``'hires'`` を
+        指定してください。デフォルト ``'0.5_mpp_150_buffer'``。
     """
     print("--- Generating plots... ---")
-    
+
+    # Build pixel-space coordinates from AnnData directly (consistent with widgets).
+    scalefactors = sp_adata_microenvironment.uns["spatial"][lib_id].get("scalefactors", {})
+    scalef = float(scalefactors.get(f"tissue_{img_key}_scalef", 1.0))
+    coords = np.asarray(sp_adata_microenvironment.obsm[basis], dtype=np.float64) * scalef
+    hires_img = sp_adata_microenvironment.uns["spatial"][lib_id]["images"][img_key]
+    h, w = hires_img.shape[:2]
+
+    merged = pd.DataFrame(
+        {
+            "x": coords[:, 0],
+            "y": coords[:, 1],
+            "predicted_microenvironment": sp_adata_microenvironment.obs["predicted_microenvironment"].values,
+        },
+        index=sp_adata_microenvironment.obs_names,
+    )
+
     # === 1. 空間散布図の作成 ===
     group_order = sorted(merged["predicted_microenvironment"].dropna().unique())
 

--- a/src/huetracer/widgets/selection.py
+++ b/src/huetracer/widgets/selection.py
@@ -91,16 +91,62 @@ def _make_color_map(labels):
     return cmap
 
 
+def _build_merged_df(sp_adata, lib_id, basis, img_key):
+    """Build a merged DataFrame with pixel-space x/y coordinates from AnnData.
+
+    Coordinates are derived from ``sp_adata.obsm[basis]`` scaled to the display
+    image space of ``img_key`` using the stored ``tissue_{img_key}_scalef``
+    scale factor.  This guarantees that the coordinate system and the
+    pixel-size conversion used by distance widgets are always consistent.
+
+    Parameters
+    ----------
+    sp_adata : AnnData
+        Spatial AnnData object.
+    lib_id : str
+        Spatial library id key in ``sp_adata.uns['spatial']``.
+    basis : str
+        Key in ``sp_adata.obsm`` containing the 2-D spatial coordinates
+        (e.g. ``'spatial_cropped_150_buffer'`` or ``'spatial'``).
+    img_key : str
+        Background image key inside ``sp_adata.uns['spatial'][lib_id]['images']``
+        (e.g. ``'0.5_mpp_150_buffer'``, ``'hires'``, or ``'lowres'``).
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame indexed by ``sp_adata.obs_names`` with columns
+        ``x``, ``y``, and any obs columns present in *sp_adata*
+        (``predicted_microenvironment``, ``predicted_cell_type``,
+        ``array_row``, ``array_col``).
+    """
+    scalefactors = sp_adata.uns["spatial"][lib_id].get("scalefactors", {})
+    scalef = float(scalefactors.get(f"tissue_{img_key}_scalef", 1.0))
+    coords = np.asarray(sp_adata.obsm[basis], dtype=np.float64) * scalef
+    df = pd.DataFrame(
+        {"x": coords[:, 0], "y": coords[:, 1]},
+        index=sp_adata.obs_names,
+    )
+    for col in ["predicted_microenvironment", "predicted_cell_type", "array_row", "array_col"]:
+        if col in sp_adata.obs.columns:
+            df[col] = sp_adata.obs[col].values
+    return df
+
+
 class _BasePlotlySelector:
     """Shared high-performance plotly selector behavior."""
 
-    def __init__(self, sp_adata, merged_df, lib_id, downsample_factor=0.25, img_key="0.5_mpp_150_buffer"):
+    def __init__(self, sp_adata, lib_id, basis="spatial_cropped_150_buffer", downsample_factor=0.25, img_key="0.5_mpp_150_buffer"):
         self.sp_adata_ref = sp_adata
-        self.merged = merged_df.copy()
-        self.merged_original = merged_df
         self.lib_id = lib_id
+        self.basis = basis
         self.downsample_factor = downsample_factor
         self.img_key = img_key
+
+        merged_df = _build_merged_df(sp_adata, lib_id, basis, img_key)
+        self.merged = merged_df
+        # Snapshot of original state used by reset operations in subclasses.
+        self.merged_original = merged_df.copy()
 
         raw_img = sp_adata.uns["spatial"][lib_id]["images"][img_key]
         self.h, self.w = raw_img.shape[:2]
@@ -341,11 +387,19 @@ class _BasePlotlySelector:
 class LassoCellSelectorMicroenvironment(_BasePlotlySelector):
     """High-performance microenvironment relabeling widget using Plotly ScatterGL."""
 
-    def __init__(self, sp_adata, merged_df, lib_id, clusters, downsample_factor=0.25, img_key="0.5_mpp_150_buffer"):
-        self.original_clusters = _as_aligned_series(clusters, merged_df.index, "predicted_microenvironment")
+    def __init__(self, sp_adata, lib_id, clusters="predicted_microenvironment", basis="spatial_cropped_150_buffer", img_key="0.5_mpp_150_buffer", downsample_factor=0.25):
+        self.clusters_col = clusters
+        self.original_clusters = _as_aligned_series(sp_adata.obs[clusters], sp_adata.obs_names, "predicted_microenvironment")
         self.current_clusters = self.original_clusters.copy()
 
-        super().__init__(sp_adata, merged_df, lib_id, downsample_factor=downsample_factor, img_key=img_key)
+        super().__init__(sp_adata, lib_id, basis=basis, downsample_factor=downsample_factor, img_key=img_key)
+
+        # Overwrite predicted_microenvironment with the caller-supplied clusters so the
+        # widget reflects the exact labels passed in (which may differ from obs if the
+        # user has not yet called _update_anndata).
+        self.merged["predicted_microenvironment"] = self.original_clusters.values
+        self.merged["predicted_microenvironment"] = self.merged["predicted_microenvironment"].astype("category")
+        self.merged_original["predicted_microenvironment"] = self.original_clusters.values
 
         self.labels = self.merged["predicted_microenvironment"].astype(str).to_numpy()
         self.group_order = [str(v) for v in self.merged["predicted_microenvironment"].dropna().unique()]
@@ -469,16 +523,14 @@ class LassoCellSelectorMicroenvironment(_BasePlotlySelector):
             self.status.value = f"<b>Status:</b> Reset failed: {exc}"
 
     def _update_anndata(self, _=None):
-        self.sp_adata_ref.obs["predicted_microenvironment"] = self.merged["predicted_microenvironment"].values
-        self.merged_original["predicted_microenvironment"] = self.merged["predicted_microenvironment"].values
+        self.sp_adata_ref.obs[self.clusters_col] = self.merged["predicted_microenvironment"].values
         self.status.value = "<b>Status:</b> AnnData updated"
 
     def _export_data(self, _=None):
         import __main__ as main
 
         main.updated_merged_export = self.merged.copy()
-        main.updated_clusters_export = self.current_clusters.copy()
-        self.status.value = "<b>Status:</b> Exported to updated_merged_export / updated_clusters_export"
+        self.status.value = "<b>Status:</b> Exported to updated_merged_export"
 
     def run(self):
         controls = widgets.VBox(
@@ -508,11 +560,22 @@ class LassoCellSelectorMicroenvironment(_BasePlotlySelector):
 class LassoCellSelectorCellType(_BasePlotlySelector):
     """High-performance cell-type relabeling widget using Plotly ScatterGL."""
 
-    def __init__(self, sp_adata, merged_df, lib_id, clusters, downsample_factor=0.25, img_key="0.5_mpp_150_buffer"):
-        self.original_clusters = _as_aligned_series(clusters, merged_df.index, "predicted_microenvironment")
+    def __init__(self, sp_adata, lib_id, clusters="predicted_microenvironment", cell_types="predicted_cell_type", basis="spatial_cropped_150_buffer", img_key="0.5_mpp_150_buffer", downsample_factor=0.25):
+        self.clusters_col = clusters
+        self.cell_types_col = cell_types
+        self.original_clusters = _as_aligned_series(sp_adata.obs[clusters], sp_adata.obs_names, "predicted_microenvironment")
         self.current_clusters = self.original_clusters.copy()
 
-        super().__init__(sp_adata, merged_df, lib_id, downsample_factor=downsample_factor, img_key=img_key)
+        super().__init__(sp_adata, lib_id, basis=basis, downsample_factor=downsample_factor, img_key=img_key)
+
+        # Overwrite predicted_microenvironment with caller-supplied clusters.
+        self.merged["predicted_microenvironment"] = self.original_clusters.values
+        self.merged["predicted_microenvironment"] = self.merged["predicted_microenvironment"].astype("category")
+        self.merged_original["predicted_microenvironment"] = self.original_clusters.values
+
+        # Overwrite predicted_cell_type with caller-supplied cell_types column.
+        self.merged["predicted_cell_type"] = sp_adata.obs[cell_types].values
+        self.merged_original["predicted_cell_type"] = sp_adata.obs[cell_types].values
 
         self.microenv_labels = self.merged["predicted_microenvironment"].astype(str).to_numpy()
         self.celltype_labels = self.merged["predicted_cell_type"].astype(str).to_numpy()
@@ -633,16 +696,14 @@ class LassoCellSelectorCellType(_BasePlotlySelector):
         self.status.value = "<b>Status:</b> Reset complete - all labels and groups restored"
 
     def _update_anndata(self, _=None):
-        self.sp_adata_ref.obs["predicted_cell_type"] = self.merged["predicted_cell_type"].values
-        self.merged_original["predicted_cell_type"] = self.merged["predicted_cell_type"].values
+        self.sp_adata_ref.obs[self.cell_types_col] = self.merged["predicted_cell_type"].values
         self.status.value = "<b>Status:</b> AnnData updated"
 
     def _export_data(self, _=None):
         import __main__ as main
 
         main.updated_merged_celltype_export = self.merged.copy()
-        main.updated_clusters_celltype_export = self.current_clusters.copy()
-        self.status.value = "<b>Status:</b> Exported to updated_merged_celltype_export / updated_clusters_celltype_export"
+        self.status.value = "<b>Status:</b> Exported to updated_merged_celltype_export"
 
     def run(self):
         controls = widgets.VBox(
@@ -676,11 +737,22 @@ class DistanceMicroenvironmentSelector(_BasePlotlySelector):
     Supports nearest, centroid, kNN mean, and distance-transform style distances.
     """
 
-    def __init__(self, sp_adata, merged_df, lib_id, clusters, downsample_factor=0.25, img_key="0.5_mpp_150_buffer"):
-        self.original_clusters = _as_aligned_series(clusters, merged_df.index, "predicted_microenvironment")
+    def __init__(self, sp_adata, lib_id, clusters="predicted_microenvironment", cell_types="predicted_cell_type", basis="spatial_cropped_150_buffer", img_key="0.5_mpp_150_buffer", downsample_factor=0.25):
+        self.clusters_col = clusters
+        self.cell_types_col = cell_types
+        self.original_clusters = _as_aligned_series(sp_adata.obs[clusters], sp_adata.obs_names, "predicted_microenvironment")
         self.current_clusters = self.original_clusters.copy()
 
-        super().__init__(sp_adata, merged_df, lib_id, downsample_factor=downsample_factor, img_key=img_key)
+        super().__init__(sp_adata, lib_id, basis=basis, downsample_factor=downsample_factor, img_key=img_key)
+
+        # Overwrite predicted_microenvironment with caller-supplied clusters.
+        self.merged["predicted_microenvironment"] = self.original_clusters.values
+        self.merged["predicted_microenvironment"] = self.merged["predicted_microenvironment"].astype("category")
+        self.merged_original["predicted_microenvironment"] = self.original_clusters.values
+
+        # Overwrite predicted_cell_type with caller-supplied cell_types column.
+        self.merged["predicted_cell_type"] = sp_adata.obs[cell_types].values
+        self.merged_original["predicted_cell_type"] = sp_adata.obs[cell_types].values
 
         # Distance mode does not use lasso/box selection; keep navigation-focused controls.
         self.selection_mode.options = [("Pan", "pan")]
@@ -1123,16 +1195,72 @@ class DistanceMicroenvironmentSelector(_BasePlotlySelector):
         self.status.value = f"<b>Status:</b> Applied '{new_label}' to {changed} cells ({target_key})"
 
     def _update_anndata(self, _=None):
-        self.sp_adata_ref.obs["predicted_microenvironment"] = self.merged["predicted_microenvironment"].values
-        self.merged_original["predicted_microenvironment"] = self.merged["predicted_microenvironment"].values
+        self.sp_adata_ref.obs[self.clusters_col] = self.merged["predicted_microenvironment"].values
         self.status.value = "<b>Status:</b> AnnData updated"
+
+    def _build_distance_matrix(self, ref_cts):
+        """Build a distance summary DataFrame indexed by CT and ME.
+
+        Parameters
+        ----------
+        ref_cts : list of str
+            Reference cell types used in the distance computation.
+
+        Returns
+        -------
+        pd.DataFrame
+            Rows: ``CT: <ref_ct>__ME: <microenvironment>``
+            Columns: count, min, p10, median, p90, max  (in current display units)
+        """
+        if self._distance_values is None:
+            return None
+
+        dists_display = self._distance_to_display_units(self._distance_values)
+        me_labels = self.microenv_labels
+        ct_label = "+".join(sorted(ref_cts))
+
+        unique_me = sorted(set(me_labels))
+
+        rows = []
+        index = []
+        for me in unique_me:
+            mask = me_labels == me
+            d = dists_display[mask]
+            if len(d) == 0:
+                continue
+            rows.append({
+                "count": int(len(d)),
+                "min": float(np.min(d)),
+                "p10": float(np.percentile(d, 10)),
+                "median": float(np.median(d)),
+                "p90": float(np.percentile(d, 90)),
+                "max": float(np.max(d)),
+            })
+            index.append(f"CT: {ct_label}__ME: {me}")
+
+        df = pd.DataFrame(rows, index=index)
+        return df
 
     def _export_data(self, _=None):
         import __main__ as main
 
         main.updated_merged_distance_export = self.merged.copy()
-        main.updated_clusters_distance_export = self.current_clusters.copy()
-        self.status.value = "<b>Status:</b> Exported to updated_merged_distance_export / updated_clusters_distance_export"
+
+        if self._distance_values is not None:
+            refs = list(self.reference_selector.value)
+            method = self.method_selector.value
+            unit = self._distance_unit_label()
+            ct_label = "+".join(sorted(refs))
+            df_name = f"{ct_label}_ME_{method}_{unit}_matrix"
+            setattr(main, df_name, self._build_distance_matrix(refs))
+            self.status.value = (
+                f"<b>Status:</b> Exported to updated_merged_distance_export, {df_name}"
+            )
+        else:
+            self.status.value = (
+                "<b>Status:</b> Exported to updated_merged_distance_export "
+                "(distance matrix skipped: run 'Compute Distances' first)"
+            )
 
     def run(self):
         controls = widgets.VBox(
@@ -1164,39 +1292,124 @@ class DistanceMicroenvironmentSelector(_BasePlotlySelector):
         return self
 
 
-def lasso_selection_microenvironment(sp_adata, merged, lib_id, clusters, downsample_factor=0.25, img_key="0.5_mpp_150_buffer"):
-    """Launch high-performance microenvironment selector."""
+def lasso_selection_microenvironment(
+    sp_adata,
+    lib_id,
+    clusters="predicted_microenvironment",
+    basis="spatial_cropped_150_buffer",
+    img_key="0.5_mpp_150_buffer",
+    downsample_factor=0.25,
+):
+    """Launch high-performance microenvironment selector.
+
+    Parameters
+    ----------
+    sp_adata : AnnData
+        Spatial AnnData with ``obsm[basis]`` coordinates and
+        ``uns['spatial'][lib_id]`` image/scalefactor data.
+    lib_id : str
+        Spatial library id.
+    clusters : str
+        Column name in ``sp_adata.obs`` to use as microenvironment labels.
+        Defaults to ``'predicted_microenvironment'``.
+    basis : str
+        Key in ``sp_adata.obsm`` for 2-D coordinates.
+    img_key : str
+        Background image key.
+    downsample_factor : float
+        Background image downsampling factor.
+    """
     selector = LassoCellSelectorMicroenvironment(
         sp_adata=sp_adata,
-        merged_df=merged,
         lib_id=lib_id,
         clusters=clusters,
+        basis=basis,
         downsample_factor=downsample_factor,
         img_key=img_key,
     )
     return selector.run()
 
 
-def lasso_selection_cell_type(sp_adata, merged, lib_id, clusters, downsample_factor=0.25, img_key="0.5_mpp_150_buffer"):
-    """Launch high-performance cell type selector."""
+def lasso_selection_cell_type(
+    sp_adata,
+    lib_id,
+    clusters="predicted_microenvironment",
+    cell_types="predicted_cell_type",
+    basis="spatial_cropped_150_buffer",
+    img_key="0.5_mpp_150_buffer",
+    downsample_factor=0.25,
+):
+    """Launch high-performance cell type selector.
+
+    Parameters
+    ----------
+    sp_adata : AnnData
+        Spatial AnnData with ``obsm[basis]`` coordinates and
+        ``uns['spatial'][lib_id]`` image/scalefactor data.
+    lib_id : str
+        Spatial library id.
+    clusters : str
+        Column name in ``sp_adata.obs`` to use as microenvironment labels.
+        Defaults to ``'predicted_microenvironment'``.
+    cell_types : str
+        Column name in ``sp_adata.obs`` to use as cell type labels.
+        Defaults to ``'predicted_cell_type'``.
+    basis : str
+        Key in ``sp_adata.obsm`` for 2-D coordinates.
+    img_key : str
+        Background image key.
+    downsample_factor : float
+        Background image downsampling factor.
+    """
     selector = LassoCellSelectorCellType(
         sp_adata=sp_adata,
-        merged_df=merged,
         lib_id=lib_id,
         clusters=clusters,
+        cell_types=cell_types,
+        basis=basis,
         downsample_factor=downsample_factor,
         img_key=img_key,
     )
     return selector.run()
 
 
-def distance_selection_microenvironment(sp_adata, merged, lib_id, clusters, downsample_factor=0.25, img_key="0.5_mpp_150_buffer"):
-    """Launch distance-based microenvironment selector."""
+def distance_selection_microenvironment(
+    sp_adata,
+    lib_id,
+    clusters="predicted_microenvironment",
+    cell_types="predicted_cell_type",
+    basis="spatial_cropped_150_buffer",
+    img_key="0.5_mpp_150_buffer",
+    downsample_factor=0.25,
+):
+    """Launch distance-based microenvironment selector.
+
+    Parameters
+    ----------
+    sp_adata : AnnData
+        Spatial AnnData with ``obsm[basis]`` coordinates and
+        ``uns['spatial'][lib_id]`` image/scalefactor data.
+    lib_id : str
+        Spatial library id.
+    clusters : str
+        Column name in ``sp_adata.obs`` to use as microenvironment labels.
+        Defaults to ``'predicted_microenvironment'``.
+    cell_types : str
+        Column name in ``sp_adata.obs`` to use as cell type labels.
+        Defaults to ``'predicted_cell_type'``.
+    basis : str
+        Key in ``sp_adata.obsm`` for 2-D coordinates.
+    img_key : str
+        Background image key.
+    downsample_factor : float
+        Background image downsampling factor.
+    """
     selector = DistanceMicroenvironmentSelector(
         sp_adata=sp_adata,
-        merged_df=merged,
         lib_id=lib_id,
         clusters=clusters,
+        cell_types=cell_types,
+        basis=basis,
         downsample_factor=downsample_factor,
         img_key=img_key,
     )

--- a/src/huetracer/widgets/selection.py
+++ b/src/huetracer/widgets/selection.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -1251,7 +1253,8 @@ class DistanceMicroenvironmentSelector(_BasePlotlySelector):
             method = self.method_selector.value
             unit = self._distance_unit_label()
             ct_label = "+".join(sorted(refs))
-            df_name = f"{ct_label}_ME_{method}_{unit}_matrix"
+            safe_ct_label = re.sub(r"[^0-9A-Za-z_]+", "_", ct_label).strip("_") or "reference"
+            df_name = f"{safe_ct_label}_ME_{method}_{unit}_matrix"
             setattr(main, df_name, self._build_distance_matrix(refs))
             self.status.value = (
                 f"<b>Status:</b> Exported to updated_merged_distance_export, {df_name}"

--- a/tutorial/microenvironment_tutorial_10x.ipynb
+++ b/tutorial/microenvironment_tutorial_10x.ipynb
@@ -395,42 +395,13 @@
    },
    "outputs": [],
    "source": [
-    "# 1. Convert cropped spatial coordinates to hires-image pixel space using the stored scale factor\n",
-    "sf_hires = sp_adata_microenvironment.uns[\"spatial\"][lib_id][\"scalefactors\"].get(f\"tissue_0.5_mpp_150_buffer_scalef\", 1.0)\n",
-    "coords_raw = sp_adata_microenvironment.obsm[\"spatial_cropped_150_buffer\"]\n",
-    "\n",
-    "# 2. Build an XY table per cell and attach object_id for stable joins\n",
-    "xy = (pd.DataFrame(coords_raw * sf_hires, \n",
-    "                           columns=[\"x\", \"y\"], \n",
-    "                           index=sp_adata_microenvironment.obs_names)\n",
-    "              .join(sp_adata_microenvironment.obs[\"object_id\"])\n",
-    "              .reset_index()\n",
-    "              .rename(columns={\"index\": \"cell_id\"}))\n",
-    "\n",
-    "# 3. Merge XY coordinates with observation metadata\n",
-    "merged = xy.merge(sp_adata_microenvironment.obs, on=\"object_id\", how=\"inner\")\n",
-    "\n",
-    "# 4. Store cluster labels for interactive relabeling widgets\n",
-    "merged[\"predicted_microenvironment\"] = clusters\n",
-    "merged[\"group\"] = merged[\"predicted_microenvironment\"]\n",
-    "\n",
-    "# 5. Cache image shape and coordinate vectors used by downstream plotting helpers\n",
-    "hires_img = sp_adata_microenvironment.uns[\"spatial\"][lib_id][\"images\"][\"0.5_mpp_150_buffer\"]\n",
-    "h, w = hires_img.shape[:2]\n",
-    "mergex = merged[\"x\"]\n",
-    "mergey = merged[\"y\"]\n",
-    "\n",
-    "# 6. Save original labels so manual edits can be reverted if needed\n",
+    "# Store original labels for reset / safety reference\n",
     "predicted_microenvironment_original = analyzer.adata.obs['leiden'].values.astype(str)\n",
     "predicted_cell_type_original = sp_adata_microenvironment.obs[\"predicted_cell_type\"].values.astype(str)\n",
     "\n",
-    "# 7. Ensure categorical dtype consistency for plotting, checkpointing, and downstream analyses\n",
+    "# Ensure categorical dtype consistency for downstream analyses\n",
     "sp_adata_microenvironment.obs['predicted_microenvironment'] = sp_adata_microenvironment.obs['predicted_microenvironment'].astype('category')\n",
-    "sp_adata_microenvironment.obs['predicted_cell_type'] = sp_adata_microenvironment.obs['predicted_cell_type'].astype('category')\n",
-    "merged[\"predicted_microenvironment\"] = merged[\"group\"].astype('category')\n",
-    "\n",
-    "# 8. Release VAE analyzer object to reduce memory footprint\n",
-    "del analyzer; clear_mem()"
+    "sp_adata_microenvironment.obs['predicted_cell_type'] = sp_adata_microenvironment.obs['predicted_cell_type'].astype('category')\n"
    ]
   },
   {
@@ -463,11 +434,8 @@
     "# AnnData (sp_adata_microenvironment)\n",
     "sp_adata_microenvironment.write_h5ad(os.path.join(_ckpt_dir, \"sp_adata_microenvironment.h5ad\"))\n",
     "\n",
-    "# DataFrame (merged)\n",
-    "merged.to_parquet(os.path.join(_ckpt_dir, \"merged.parquet\"))\n",
     "\n",
     "# NumPy arrays\n",
-    "np.save(os.path.join(_ckpt_dir, \"clusters.npy\"), np.array(clusters, dtype=object))\n",
     "np.save(os.path.join(_ckpt_dir, \"predicted_microenvironment_original.npy\"), predicted_microenvironment_original)\n",
     "np.save(os.path.join(_ckpt_dir, \"predicted_cell_type_original.npy\"), predicted_cell_type_original)\n",
     "\n",
@@ -478,7 +446,6 @@
     "print(f\"✅ Checkpoint saved to: {_ckpt_dir}\")\n",
     "print(\"  - sp_adata_microenvironment.h5ad\")\n",
     "print(\"  - merged.parquet\")\n",
-    "print(\"  - clusters.npy\")\n",
     "print(\"  - predicted_microenvironment_original.npy\")\n",
     "print(\"  - predicted_cell_type_original.npy\")\n",
     "print(\"  - meta.json\")\n"
@@ -539,11 +506,8 @@
     "# AnnData (sp_adata_microenvironment)\n",
     "sp_adata_microenvironment = sc.read_h5ad(os.path.join(_ckpt_dir, \"sp_adata_microenvironment.h5ad\"))\n",
     "\n",
-    "# DataFrame (merged)\n",
-    "merged = pd.read_parquet(os.path.join(_ckpt_dir, \"merged.parquet\"))\n",
     "\n",
     "# NumPy arrays\n",
-    "clusters = np.load(os.path.join(_ckpt_dir, \"clusters.npy\"), allow_pickle=True)\n",
     "predicted_microenvironment_original = np.load(\n",
     "    os.path.join(_ckpt_dir, \"predicted_microenvironment_original.npy\"), allow_pickle=True\n",
     ")\n",
@@ -567,8 +531,7 @@
     "    print(f\"⚠️  sp_adata_raw not found at: {h5ad_save_path}\")\n",
     "\n",
     "print(f\"✅ Checkpoint loaded from: {_ckpt_dir}\")\n",
-    "print(f\"   sp_adata_microenvironment: {sp_adata_microenvironment.shape}\")\n",
-    "print(f\"   merged: {merged.shape}, clusters: {len(clusters)}, lib_id: {lib_id}\")\n"
+    "print(f\"   sp_adata_microenvironment: {sp_adata_microenvironment.shape}\")"
    ]
   },
   {
@@ -699,12 +662,13 @@
     "# =========================\n",
     "\n",
     "selector = huetracer.lasso_selection_microenvironment(\n",
-    "    sp_adata_microenvironment,\n",
-    "    merged,\n",
-    "    lib_id,\n",
-    "    clusters,\n",
-    "    downsample_factor=0.05, # downsample_factor=lasso_downsample_factor,\n",
-    ")"
+    "    sp_adata=sp_adata_microenvironment,\n",
+    "    lib_id=lib_id,\n",
+    "    clusters='predicted_microenvironment',\n",
+    "    basis='spatial_cropped_150_buffer', # or 'spatial'\n",
+    "    img_key='0.5_mpp_150_buffer', # or 'lowres'/'hires'\n",
+    "    downsample_factor=0.05, # or lasso_downsample_factor\n",
+    ")\n"
    ]
   },
   {
@@ -741,12 +705,14 @@
     "# =========================\n",
     "\n",
     "selector = huetracer.distance_selection_microenvironment(\n",
-    "    sp_adata_microenvironment,\n",
-    "    merged,\n",
-    "    lib_id,\n",
-    "    clusters,\n",
-    "    downsample_factor=0.05, # downsample_factor=lasso_downsample_factor,\n",
-    ")"
+    "    sp_adata=sp_adata_microenvironment,\n",
+    "    lib_id=lib_id,\n",
+    "    clusters='predicted_microenvironment',\n",
+    "    cell_types='predicted_cell_type',\n",
+    "    basis='spatial_cropped_150_buffer',\n",
+    "    img_key='0.5_mpp_150_buffer',\n",
+    "    downsample_factor=0.05, # or lasso_downsample_factor\n",
+    ")\n"
    ]
   },
   {
@@ -783,11 +749,13 @@
     "# =========================\n",
     "\n",
     "selector = huetracer.lasso_selection_cell_type(\n",
-    "    sp_adata_microenvironment,\n",
-    "    merged,\n",
-    "    lib_id,\n",
-    "    clusters,\n",
-    "    downsample_factor=0.25\n",
+    "    sp_adata=sp_adata_microenvironment,\n",
+    "    lib_id=lib_id,\n",
+    "    clusters='predicted_microenvironment',\n",
+    "    cell_types='predicted_cell_type',\n",
+    "    basis='spatial_cropped_150_buffer',\n",
+    "    img_key='0.5_mpp_150_buffer',\n",
+    "    downsample_factor=0.05, # or lasso_downsample_factor,\n",
     ")"
    ]
   },
@@ -812,9 +780,7 @@
     "# Reset modification\n",
     "# \n",
     "# sp_adata_microenvironment.obs['predicted_microenvironment'] = predicted_microenvironment_original\n",
-    "# sp_adata_microenvironment.obs['predicted_cell_type'] = predicted_cell_type_original\n",
-    "# merged[\"predicted_microenvironment\"] = predicted_microenvironment_original\n",
-    "# merged[\"predicted_cell_type\"] = predicted_cell_type_original"
+    "# sp_adata_microenvironment.obs['predicted_cell_type'] = predicted_cell_type_original\n"
    ]
   },
   {
@@ -948,18 +914,14 @@
    "outputs": [],
    "source": [
     "# Spatial scatter plot + cell-type composition heatmap\n",
-    "hires_img = sp_adata_microenvironment.uns[\"spatial\"][lib_id][\"images\"][\"0.5_mpp_150_buffer\"]\n",
-    "h, w = hires_img.shape[:2]\n",
-    "\n",
     "huetracer.plot.create_report_plots(\n",
-    "    merged=merged,\n",
     "    sp_adata_microenvironment=sp_adata_microenvironment,\n",
-    "    hires_img=hires_img,\n",
-    "    w=w,\n",
-    "    h=h,\n",
+    "    lib_id=lib_id,\n",
     "    sample_name=SAMPLE_NAME,\n",
     "    save_path=RESULTS_PATH,\n",
-    ")"
+    "    basis=\"spatial_cropped_150_buffer\",\n",
+    "    img_key=\"0.5_mpp_150_buffer\",\n",
+    ")\n"
    ]
   },
   {

--- a/tutorial/microenvironment_tutorial_10x.ipynb
+++ b/tutorial/microenvironment_tutorial_10x.ipynb
@@ -445,7 +445,6 @@
     "\n",
     "print(f\"✅ Checkpoint saved to: {_ckpt_dir}\")\n",
     "print(\"  - sp_adata_microenvironment.h5ad\")\n",
-    "print(\"  - merged.parquet\")\n",
     "print(\"  - predicted_microenvironment_original.npy\")\n",
     "print(\"  - predicted_cell_type_original.npy\")\n",
     "print(\"  - meta.json\")\n"


### PR DESCRIPTION
## 概要

`DistanceMicroenvironmentSelector`・`LassoCellSelectorMicroenvironment`・`LassoCellSelectorCellType` および `create_report_plots` 系関数の以下3点を改善しました。

1. **座標系の統一** : `merged_df` の外部渡しをやめ、`basis` / `img_key` パラメータで内部構築するよう設計を一本化
2. **距離単位換算の修正** : pixel → µm 換算をスケールファクタから正しく導出
3. **距離マトリクスエクスポート機能の追加** : 特定の細胞タイプと各 microenvironment 間の距離一覧を DataFrame として出力
4. その他、bug-fix

---

## 変更内容

### 1. 座標系の統一と `img_key` 汎用化

**変更前：** 呼び出し元が `merged_df`（加工済み DataFrame）を手動で作成して渡す必要があり、`"0.5_mpp_150_buffer"` 以外の画像キーでは正しく動作しなかった

**変更後：**
- `_build_merged_df(sp_adata, lib_id, basis, img_key)` を共通関数として新設し、すべてのセレクタが内部で呼び出す
- 生座標（`sp_adata.obsm[basis]`）に `tissue_{img_key}_scalef` を乗算して `merged["x"/"y"]` を **`img_key` 表示画像のピクセル空間** に統一
- `img_key` に `"hires"`・`"lowres"` を指定した場合も、対応する `scalef` を自動取得して正しく動作するよう汎用化
- `LassoCellSelectorMicroenvironment`・`LassoCellSelectorCellType`・`DistanceMicroenvironmentSelector` のすべての `__init__` シグネチャを `basis=`・`img_key=` に統一
- `create_report_plots` 系のラッパー関数にも同パラメータを追加・伝播

### 2. pixel → µm 換算の修正（`_infer_pixel_size_um`）

**変更前：** pixel サイズがデフォルト値のハードコードになっていた  
**変更後：** `scalefactors` から以下の式で正しく算出

```
pixel_size_um = microns_per_pixel（fullres） / tissue_{img_key}_scalef
```

- 距離計算はピクセル空間で実行し、UI 表示・エクスポート時に `pixel_size_um` で µm に換算
- `distance_transform` 方式では、ビングリッド距離を `bin_size_um / pixel_size_um` でスケール補正し、物理空間に揃える

### 3. 距離マトリクスエクスポート機能の追加（`_build_distance_matrix`、`_export_data`）

「Compute Distances」実行後に「Export」ボタンを押すと、距離サマリーを DataFrame として書き出す機能を追加

**エクスポートされるオブジェクト：**

| 変数名 | 内容 |
|---|---|
| `updated_merged_distance_export` | `merged` DataFrame のスナップショット（全スポット情報） |
| `{CT}_ME_{method}_{unit}_matrix` | 距離サマリーマトリクス |

**距離サマリーマトリクスの構造：**

- **行インデックス：** `CT: {リファレンス細胞タイプ}__ME: {microenvironment}`
- **列：** `count`、`min`、`p10`、`median`、`p90`、`max`（表示単位 um または px）

**使用例（`CancerCell` を Reference CT、方法 `nearest`、単位 `um` の場合）：**

```python
# ウィジェット起動 → Compute Distances → Export ボタン押下後
import __main__ as main

df = main.CancerCell_ME_nearest_um_matrix
df
# 例:
#                                    count   min    p10  median    p90    max
# CT: CancerCell__ME: Stroma          312   8.5   12.3    24.1   58.7   120.3
# CT: CancerCell__ME: TumorCore       205   4.2    6.8    15.9   44.2    98.7
```

### 4. その他

- `plot.plot_spatial_plotly_fast`関数における`point_opacity`が反映されない不具合を修正
- パラメータの並び順の微修正


---

## 関連 Issue

- Closes #24